### PR TITLE
Removed ZEN related bug

### DIFF
--- a/ZEI/functions/fn_init.sqf
+++ b/ZEI/functions/fn_init.sqf
@@ -1,8 +1,57 @@
-if hasInterface then {
-	[] spawn {
-		// Wait until logic is present.
-		waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
-		// Add EH to spawn ZEI Modules.
-		(getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
-	};
+if (hasInterface) then {
+ if (isServer || {!(isClass (configFile >> "CfgPatches" >> "zen_common"))}) then {
+  [] spawn {
+   // Wait until logic is present.
+   waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
+   // Add EH to spawn ZEI Modules.
+   (getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
+  };
+ } else {
+  // Only add separate ZEN modules if ZEN is loaded and if not server (to avoid duplicate modules in curator list)
+  // This is to prevent a bug where all other ZEN modules that were added per script would be in the wrong categories and mixed up; Bug doesn't happen if the client is the server
+
+  ["Interiors (ZEI)", "Garrison Building", {
+   params ["_pos"];
+
+   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_garrisonBuilding" requirement)
+   private _temp = "Module_F" createVehicleLocal _pos;
+
+   ["init", [_temp, true, true]] call ZEI_fnc_mod_garrisonBuilding;
+
+   deleteVehicle _temp;
+  }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\rifle_ca.paa"] call zen_custom_modules_fnc_register;
+
+  ["Interiors (ZEI)", "Object Fill", {
+   params ["_pos"];
+
+   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectFill" requirement)
+   private _temp = "Module_F" createVehicleLocal _pos;
+
+   ["init", [_temp, true, true]] call ZEI_fnc_mod_objectFill;
+
+   deleteVehicle _temp;
+  }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\box_ca.paa"] call zen_custom_modules_fnc_register;
+
+  ["Interiors (ZEI)", "Object Switch", {
+   params ["_pos"];
+
+   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectSwitch" requirement)
+   private _temp = "Module_F" createVehicleLocal _pos;
+
+   ["init", [_temp, true, true]] call ZEI_fnc_mod_objectSwitch;
+
+   deleteVehicle _temp;
+  }, "\A3\Modules_f\data\portraitRespawn_ca.paa"] call zen_custom_modules_fnc_register;
+
+  ["Interiors (ZEI)", "Interior Fill", {
+   params ["_pos"];
+
+   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_interiorFill" requirement)
+   private _temp = "Module_F" createVehicleLocal _pos;
+
+   ["init", [_temp, true, true]] call ZEI_fnc_mod_interiorFill;
+
+   deleteVehicle _temp;
+  }, "\A3\modules_f\data\portraitModule_ca.paa"] call zen_custom_modules_fnc_register;
+ };
 };

--- a/ZEI/functions/fn_init.sqf
+++ b/ZEI/functions/fn_init.sqf
@@ -1,10 +1,10 @@
 if (hasInterface) then {
     if (isServer || {!(isClass (configFile >> "CfgPatches" >> "zen_common"))}) then {
         [] spawn {
-         // Wait until logic is present.
-         waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
-         // Add EH to spawn ZEI Modules.
-         (getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
+            // Wait until logic is present.
+            waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
+            // Add EH to spawn ZEI Modules.
+            (getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
         };
     } else {
         // Only add separate ZEN modules if ZEN is loaded and if not server (to avoid duplicate modules in curator list)

--- a/ZEI/functions/fn_init.sqf
+++ b/ZEI/functions/fn_init.sqf
@@ -1,57 +1,57 @@
 if (hasInterface) then {
- if (isServer || {!(isClass (configFile >> "CfgPatches" >> "zen_common"))}) then {
-  [] spawn {
-   // Wait until logic is present.
-   waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
-   // Add EH to spawn ZEI Modules.
-   (getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
-  };
- } else {
-  // Only add separate ZEN modules if ZEN is loaded and if not server (to avoid duplicate modules in curator list)
-  // This is to prevent a bug where all other ZEN modules that were added per script would be in the wrong categories and mixed up; Bug doesn't happen if the client is the server
+    if (isServer || {!(isClass (configFile >> "CfgPatches" >> "zen_common"))}) then {
+        [] spawn {
+         // Wait until logic is present.
+         waitUntil {sleep 1; !isNull (getAssignedCuratorLogic player)};
+         // Add EH to spawn ZEI Modules.
+         (getAssignedCuratorLogic player) addEventHandler ["CuratorObjectRegistered", { [] spawn ZEI_fnc_zeus_addModules }];
+        };
+    } else {
+        // Only add separate ZEN modules if ZEN is loaded and if not server (to avoid duplicate modules in curator list)
+        // This is to prevent a bug where all other ZEN modules that were added per script would be in the wrong categories and mixed up; Bug doesn't happen if the client is the server
 
-  ["Interiors (ZEI)", "Garrison Building", {
-   params ["_pos"];
+        ["Interiors (ZEI)", "Garrison Building", {
+            params ["_pos"];
 
-   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_garrisonBuilding" requirement)
-   private _temp = "Module_F" createVehicleLocal _pos;
+            // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_garrisonBuilding" requirement)
+            private _temp = "Module_F" createVehicleLocal _pos;
 
-   ["init", [_temp, true, true]] call ZEI_fnc_mod_garrisonBuilding;
+            ["init", [_temp, true, true]] call ZEI_fnc_mod_garrisonBuilding;
 
-   deleteVehicle _temp;
-  }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\rifle_ca.paa"] call zen_custom_modules_fnc_register;
+            deleteVehicle _temp;
+        }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\rifle_ca.paa"] call zen_custom_modules_fnc_register;
 
-  ["Interiors (ZEI)", "Object Fill", {
-   params ["_pos"];
+        ["Interiors (ZEI)", "Object Fill", {
+            params ["_pos"];
 
-   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectFill" requirement)
-   private _temp = "Module_F" createVehicleLocal _pos;
+            // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectFill" requirement)
+            private _temp = "Module_F" createVehicleLocal _pos;
 
-   ["init", [_temp, true, true]] call ZEI_fnc_mod_objectFill;
+            ["init", [_temp, true, true]] call ZEI_fnc_mod_objectFill;
 
-   deleteVehicle _temp;
-  }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\box_ca.paa"] call zen_custom_modules_fnc_register;
+            deleteVehicle _temp;
+        }, "\A3\ui_f\data\igui\cfg\simpleTasks\types\box_ca.paa"] call zen_custom_modules_fnc_register;
 
-  ["Interiors (ZEI)", "Object Switch", {
-   params ["_pos"];
+        ["Interiors (ZEI)", "Object Switch", {
+            params ["_pos"];
 
-   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectSwitch" requirement)
-   private _temp = "Module_F" createVehicleLocal _pos;
+            // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_objectSwitch" requirement)
+            private _temp = "Module_F" createVehicleLocal _pos;
 
-   ["init", [_temp, true, true]] call ZEI_fnc_mod_objectSwitch;
+            ["init", [_temp, true, true]] call ZEI_fnc_mod_objectSwitch;
 
-   deleteVehicle _temp;
-  }, "\A3\Modules_f\data\portraitRespawn_ca.paa"] call zen_custom_modules_fnc_register;
+            deleteVehicle _temp;
+        }, "\A3\Modules_f\data\portraitRespawn_ca.paa"] call zen_custom_modules_fnc_register;
 
-  ["Interiors (ZEI)", "Interior Fill", {
-   params ["_pos"];
+        ["Interiors (ZEI)", "Interior Fill", {
+            params ["_pos"];
 
-   // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_interiorFill" requirement)
-   private _temp = "Module_F" createVehicleLocal _pos;
+            // Give a temp object, because objNull is not local (because of "ZEI_fnc_mod_interiorFill" requirement)
+            private _temp = "Module_F" createVehicleLocal _pos;
 
-   ["init", [_temp, true, true]] call ZEI_fnc_mod_interiorFill;
+            ["init", [_temp, true, true]] call ZEI_fnc_mod_interiorFill;
 
-   deleteVehicle _temp;
-  }, "\A3\modules_f\data\portraitModule_ca.paa"] call zen_custom_modules_fnc_register;
- };
+            deleteVehicle _temp;
+        }, "\A3\modules_f\data\portraitModule_ca.paa"] call zen_custom_modules_fnc_register;
+    };
 };


### PR DESCRIPTION
There is an issue if ZEN and ZEI are loaded at the same time and the interface is opened using the "openCuratorInterface" command. ZEI would mix up all custom modules added per script from ZEN.
The only way to fix it was to manually get out of Zeus and back in.
However, this commit should fix the issue by adding native ZEN modules when necessary.
This bug did not occur if the client was the server (host).

I added only the 4 visible modules to ZEN, as I figured the dev ones weren't necessary to add to ZEN.

Picture of how the modules should be categorised:

![20210709135327_1](https://user-images.githubusercontent.com/58661205/125087770-0fa01900-e0cd-11eb-9aea-f213483de631.jpg)

Picture of how the modules look like when ZEI is loaded and `openCuratorInterface` is used prior to this update:

![20210709135544_1](https://user-images.githubusercontent.com/58661205/125087874-29d9f700-e0cd-11eb-8227-5dd8863accaf.jpg)