### PR TITLE
Feature: level of detail for interior fill

### DIFF
--- a/ZEI/CfgFunctions.hpp
+++ b/ZEI/CfgFunctions.hpp
@@ -4,6 +4,7 @@ class CfgFunctions {
 			file = "\zei\functions";
 			class addCustomHouse {};
 			class addCustomTemplate {};
+			class checkDetailLevel {};		// InteriorFill
 			class createTemplate {};		// InteriorFill
 			class garrisonUnit {};			// garrisonBuilding
 			class findTemplates {};			// InteriorFill

--- a/ZEI/functions/fn_checkDetailLevel.sqf
+++ b/ZEI/functions/fn_checkDetailLevel.sqf
@@ -1,0 +1,16 @@
+// Called from ZEI_fnc_createTemplate
+params ["_item", "_detailLevel"];
+
+// If the detailLevel is at maximum, just exitWith true to save time
+if( _detailLevel == 1) exitWith { TRUE };
+
+private _classList = switch(_detailLevel) do {
+	case 0: { ["BagFence_base_F", "BagBunker_base_F", "Land_Shoot_House_Wall_F"] };
+	
+	// TODO: Could be expanded with intermediate detail levels, e.g.:
+	// case 1: { ["Building"] };
+
+	default { ["All"] };
+};
+
+_classList findIf { _item isKindOf [_x, configFile >> "CfgVehicles"] } != -1

--- a/ZEI/functions/fn_createTemplate.sqf
+++ b/ZEI/functions/fn_createTemplate.sqf
@@ -4,10 +4,11 @@ params [
 		["_fillType", "mil"],
 		["_fillArea", FALSE],
 		["_addZeus", TRUE],
-		["_allowDamage", FALSE]
+		["_allowDamage", FALSE],
+		["_detail", 1]
 	];
 
-[format ["Passed - B: %1 T: %2 A: %3 Z: %4 D: %5", _bld, _fillType, _fillArea, _addZeus, _allowDamage], "DEBUG"] call ZEI_fnc_misc_logMsg;
+[format ["Passed - B: %1 T: %2 A: %3 Z: %4 D: %5 M: %6", _bld, _fillType, _fillArea, _addZeus, _allowDamage, _detail], "DEBUG"] call ZEI_fnc_misc_logMsg;
 	
 // Skip previously processed houses
 if (isNull _bld || !isNull (_bld getVariable ["zei_furnished", objNull])) exitWith {};
@@ -38,8 +39,8 @@ if !(_templates isEqualTo []) then {
 		{ 
 			_x params ["_item", "_offset", ["_angle", 0], ["_rot", [0, 0, 0]]]; 
 			_item = [_item] call ZEI_fnc_randomiseObject;
-			
-			if (_item != "") then {
+
+			if (_item != "" && ([_item, _detail] call ZEI_fnc_checkDetailLevel) ) then {
 				_obj = create3DENEntity ["Object", _item, [0,0,0], TRUE]; 
 				_obj set3DENAttribute ["objectIsSimple", TRUE]; 
 				_obj setVectorDirAndUp [vectorDir _bld, vectorUp _bld];
@@ -72,7 +73,7 @@ if !(_templates isEqualTo []) then {
 			_x params ["_item", "_offset", ["_angle", 0], ["_rot", [0, 0, 0]]];
 			_item = [_item] call ZEI_fnc_randomiseObject;
 			
-			if (_item != "") then {
+			if (_item != "" && ([_item, _detail] call ZEI_fnc_checkDetailLevel) ) then {
 				if (_addZeus) then {
 					_obj = createVehicle [_item, (_bld modelToWorld _offset), [], 0, "CAN_COLLIDE"];
 					[_obj, FALSE] remoteExec ["enableSimulationGlobal", 2];

--- a/ZEI/functions/fn_ui_interiorFill.sqf
+++ b/ZEI/functions/fn_ui_interiorFill.sqf
@@ -2,7 +2,8 @@ params [
 		["_type", 0],
 		["_area", 0],
 		["_addZeus", TRUE],
-		["_allowDamage", FALSE]
+		["_allowDamage", FALSE],
+		["_detail", 1]
 	];
 
 private _fillType = if (_type isEqualTo 0) then { "mil" } else { "civ" };
@@ -10,6 +11,7 @@ private _fillArea = if (_area isEqualTo 0) then { FALSE } else { TRUE };
 
 // Save UI Settings for next time
 ZEI_UiInteriorType = _type;
+ZEI_UiInteriorDetail = _detail;
 ZEI_UiInteriorEdit = _addZeus;
 ZEI_UiInteriorDamage = _allowDamage;
 
@@ -35,11 +37,11 @@ if (_bldArr isEqualTo []) exitWith {
 if (is3DEN) then {
 	collect3DENHistory {
 		{
-			[_x, _fillType, _fillArea, _addZeus, _allowDamage] call ZEI_fnc_createTemplate;
+			[_x, _fillType, _fillArea, _addZeus, _allowDamage, _detail] call ZEI_fnc_createTemplate;
 		} forEach _bldArr;
 	};
 } else {
 	{
-		[_x, _fillType, _fillArea, _addZeus, _allowDamage] call ZEI_fnc_createTemplate;
+		[_x, _fillType, _fillArea, _addZeus, _allowDamage, _detail] call ZEI_fnc_createTemplate;
 	} forEach _bldArr;
 };

--- a/ZEI/ui/Rsc_ZEI_InteriorFill.hpp
+++ b/ZEI/ui/Rsc_ZEI_InteriorFill.hpp
@@ -11,6 +11,7 @@ class Rsc_ZEI_InteriorFill
 		ZEI_IF_Text_Title,
 		ZEI_IF_Text_Type,
 		ZEI_IF_Text_Items,
+		ZEI_IF_Text_Detail,
 		ZEI_IF_Text_EditObject,
 		ZEI_IF_Text_AllowDamage
 	};
@@ -18,6 +19,7 @@ class Rsc_ZEI_InteriorFill
 	controls[]={
 		ZEI_IF_Combo_Type,
 		ZEI_IF_Slider_Items,
+		ZEI_IF_Combo_Detail,
 		ZEI_IF_CheckBox_EditObject,
 		ZEI_IF_CheckBox_AllowDamage,
 		ZEI_IF_Button_OK,
@@ -30,7 +32,7 @@ class Rsc_ZEI_InteriorFill
 		x = 0.335 * safezoneW + safezoneX;
 		y = 0.324 * safezoneH + safezoneY;
 		w = 0.2475 * safezoneW;
-		h = 0.262 * safezoneH;
+		h = 0.31 * safezoneH;
 	};
 	class ZEI_IF_Frame: ZEI_RscFrame
 	{
@@ -38,7 +40,7 @@ class Rsc_ZEI_InteriorFill
 		x = 0.335 * safezoneW + safezoneX;
 		y = 0.324 * safezoneH + safezoneY;
 		w = 0.2475 * safezoneW;
-		h = 0.262 * safezoneH;
+		h = 0.31 * safezoneH;
 	};
 	class ZEI_IF_Text_Title: ZEI_RscText
 	{
@@ -97,12 +99,35 @@ class Rsc_ZEI_InteriorFill
 			(findDisplay 1705 displayCtrl 20) sliderSetPosition 0;\
 		};";
 	};
+	class ZEI_IF_Text_Detail: ZEI_RscText
+	{
+		idc = 5;
+		text = "Level of Detail";
+		x = 0.340156 * safezoneW + safezoneX;
+		y = 0.457 * safezoneH + safezoneY;
+		w = 0.0567187 * safezoneW;
+		h = 0.022 * safezoneH;
+	};
+	class ZEI_IF_Combo_Detail: ZEI_RscCombo
+	{
+		idc = 50;
+		x = 0.432969 * safezoneW + safezoneX;
+		y = 0.457 * safezoneH + safezoneY;
+		w = 0.139219 * safezoneW;
+		h = 0.022 * safezoneH;
+		tooltip = "Level of complexity for interiors";
+		onLoad= "_this spawn {\
+			waitUntil { !isNull (_this select 0) };\
+			{ (findDisplay 1705 displayCtrl 50) lbAdd _x } forEach ['Defences Only', 'Full'];\
+			(findDisplay 1705 displayCtrl 50) lbSetCurSel (missionNamespace getVariable ['ZEI_UiInteriorDetail', 1]);\
+		}";
+	};
 	class ZEI_IF_Text_EditObject: ZEI_RscText
 	{
 		idc = 3;
 		text = "Edit Objects"; //--- ToDo: Localize;
 		x = 0.340156 * safezoneW + safezoneX;
-		y = 0.467 * safezoneH + safezoneY;
+		y = 0.501 * safezoneH + safezoneY;
 		w = 0.0845 * safezoneW;
 		h = 0.022 * safezoneH;
 		onLoad= "_this spawn { waitUntil { !isNull (_this select 0) };\
@@ -113,7 +138,7 @@ class Rsc_ZEI_InteriorFill
 	{
 		idc = 30;
 		x = 0.422656 * safezoneW + safezoneX;
-		y = 0.467 * safezoneH + safezoneY;
+		y = 0.501 * safezoneH + safezoneY;
 		w = 0.020625 * safezoneW;
 		h = 0.033 * safezoneH;
 		tooltip = "Add the spawned objects to Curator\nIf disabled, they cannot be moved or edited by Zeus.";
@@ -128,7 +153,7 @@ class Rsc_ZEI_InteriorFill
 		idc = 4;
 		text = "Allow Damage"; //--- ToDo: Localize;
 		x = 0.340156 * safezoneW + safezoneX;
-		y = 0.511 * safezoneH + safezoneY;
+		y = 0.545 * safezoneH + safezoneY;
 		w = 0.0845 * safezoneW;
 		h = 0.022 * safezoneH;
 		onLoad= "_this spawn { waitUntil { !isNull (_this select 0) };\
@@ -139,7 +164,7 @@ class Rsc_ZEI_InteriorFill
 	{
 		idc = 40;
 		x = 0.422656 * safezoneW + safezoneX;
-		y = 0.511 * safezoneH + safezoneY;
+		y = 0.545 * safezoneH + safezoneY;
 		w = 0.020625 * safezoneW;
 		h = 0.033 * safezoneH;
 		tooltip = "Allow the building to be damaged.\nIf enabled, all objects inside the building may be left 'floating' when damaged/destroyed.";
@@ -148,23 +173,22 @@ class Rsc_ZEI_InteriorFill
 			if is3DEN then { (findDisplay 1705 displayCtrl 40) ctrlShow FALSE; };\
 		}";
 	};
-	
 	class ZEI_IF_Button_OK: ZEI_RscButton
 	{
 		idc = -1;
 		text = "OK"; //--- ToDo: Localize;
 		x = 0.360781 * safezoneW + safezoneX;
-		y = 0.542 * safezoneH + safezoneY;
+		y = 0.599 * safezoneH + safezoneY;
 		w = 0.04125 * safezoneW;
 		h = 0.022 * safezoneH;
-		onButtonClick  = "[ lbCurSel (findDisplay 1705 displayCtrl 10), round (sliderPosition (findDisplay 1705 displayCtrl 20)), cbChecked (findDisplay 1705 displayCtrl 30), cbChecked (findDisplay 1705 displayCtrl 40) ] spawn ZEI_fnc_ui_interiorFill; (findDisplay 1705) closeDisplay 1;";
+		onButtonClick  = "[ lbCurSel (findDisplay 1705 displayCtrl 10), round (sliderPosition (findDisplay 1705 displayCtrl 20)), cbChecked (findDisplay 1705 displayCtrl 30), cbChecked (findDisplay 1705 displayCtrl 40), lbCurSel (findDisplay 1705 displayCtrl 50) ] spawn ZEI_fnc_ui_interiorFill; (findDisplay 1705) closeDisplay 1;";
 	};
 	class ZEI_IF_Button_Cancel: ZEI_RscButton
 	{
 		idc = -1;
 		text = "Cancel"; //--- ToDo: Localize;
 		x = 0.494844 * safezoneW + safezoneX;
-		y = 0.542 * safezoneH + safezoneY;
+		y = 0.599 * safezoneH + safezoneY;
 		w = 0.04125 * safezoneW;
 		h = 0.022 * safezoneH;
 		onButtonClick  = "(findDisplay 1705) closeDisplay 2;";


### PR DESCRIPTION
Added a UI option to constrain the "level of detail" of interior fill, resolves #15.

This allows the user to choose to only place defensive objects (i.e. sandbags, bunkers, and shoot-house walls), in order to minimise the number of objects added to the mission.

Using a dropdown menu allows for future expansion, and the inclusion of additional preset "detail levels"